### PR TITLE
Fix locale settings to en_US.UTF-8

### DIFF
--- a/script/desktop.sh
+++ b/script/desktop.sh
@@ -60,3 +60,6 @@ NODPMS_CONFIG=/etc/xdg/autostart/nodpms.desktop
     echo "Comment=" >> $NODPMS_CONFIG
 fi
 
+if [[ $DISTRIB_RELEASE == 16.04 ]]; then
+  sudo update-locale LANG=en_US.UTF-8 LANGUAGE=en_US
+fi


### PR DESCRIPTION
Without this fix the terminal app won't start. This issue can be found on almost all of the available Vagrant boxes, even on the official one from Ubuntu.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>