### PR TITLE
Always provision with apt-get upgrade

### DIFF
--- a/script/update.sh
+++ b/script/update.sh
@@ -16,6 +16,7 @@ fi
 echo "==> Updating list of repositories"
 # apt-get update does not actually perform updates, it just downloads and indexes the list of packages
 apt-get -y update
+apt-get -y upgrade
 
 if [[ $UPDATE  =~ true || $UPDATE =~ 1 || $UPDATE =~ yes ]]; then
     echo "==> Performing dist-upgrade (all packages and kernel)"


### PR DESCRIPTION
In order to provision the very latest package versions, we should always run an `apt-get upgrade`. So we make sure to provision the very latest Ubuntu version up to date.

Signed-off-by: Dieter Reuter <dieter.reuter@me.com>